### PR TITLE
Bootloader updater from v3.x to v5.0

### DIFF
--- a/v3_to_v5_updater/drivers/efr32xg12/flash.c
+++ b/v3_to_v5_updater/drivers/efr32xg12/flash.c
@@ -1,0 +1,184 @@
+/* Copyright 2018 Wirepas Ltd. All Rights Reserved.
+ *
+ * See file LICENSE.txt for full license details.
+ *
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include "mcu.h"
+#include "flash.h"
+
+/* Driver specifics */
+#define FLASH_BASE_BAND_CFG     CMU_AUXHFRCOCTRL_BAND_14MHZ
+#define FLASH_BASE_BAND_HZ      14000000ul
+
+/**
+ * \brief   Enable writing to flash.
+ *          Not necessary with EFR32
+ * \return  none
+ */
+void Flash_enableWrite(void)
+{
+    // Not necessary with EFM32
+}
+
+/**
+ * \brief   Enable flash erase.
+ *          Not necessary with EFR32
+ * \return  none
+ */
+void Flash_enableErase(void)
+{
+    // Not necessary with EFM32
+}
+
+
+/* Low level access for hardware */
+__STATIC_INLINE void Flash_waitBusy(void)
+{
+    /* Wait for the write to complete */
+    while ((MSC->STATUS & MSC_STATUS_BUSY))
+    {
+    }
+}
+
+__STATIC_INLINE void Flash_waitWrite(void)
+{
+    while ((MSC->STATUS & MSC_STATUS_WDATAREADY) == 0)
+    {
+    }
+}
+
+__STATIC_INLINE void Flash_setBaseAddress(uint32_t addr)
+{
+    MSC->ADDRB = addr;
+    MSC->WRITECMD = MSC_WRITECMD_LADDRIM;
+}
+
+__STATIC_INLINE void Flash_startErase(void)
+{
+    MSC->WRITECMD = MSC_WRITECMD_ERASEPAGE;
+}
+
+/**
+ * \brief   Enable write and erase access of the flash.
+ * Internal function not in flash.h
+ * \return  none
+ */
+void Flash_enableAccess(void)
+{
+    /* Enable writing to the MSC */
+    MSC->WRITECTRL |= MSC_WRITECTRL_WREN;
+}
+
+
+/**
+ * \brief   Disables write and erase access of the flash.
+ * \return  none
+ */
+void Flash_disableAccess(void)
+{
+    /* Disable writing to the MSC */
+    MSC->WRITECTRL &= ~MSC_WRITECTRL_WREN;
+}
+
+/**
+ * \brief   To initialize flash HW.
+ * In EFR32 only the MSC registers need to be initialized
+ * \return  none
+ */
+void Flash_init(void)
+{
+/* Flash clock control changed from EZR, See spec section 8.3.12 and 12.3.  */
+
+/* Do not invalidate instruction cache when writing to Flash */
+    MSC->READCTRL |= MSC_READCTRL_AIDIS;
+
+    /* Unlock the MSC */
+    MSC->LOCK = MSC_UNLOCK_CODE;
+
+    RMU->CTRL = 0x00004444;
+
+    /* Disable writing to the flash */
+    Flash_disableAccess();
+
+}
+
+/* Access for hardware (FLASH MSC) */
+void __attribute__ ((section(".ramtext")))
+Flash_write(void * to, const void * from, size_t amount)
+{
+    uint32_t p_words, written;
+    uint32_t * p_base = to;
+ #if defined(_SILICON_LABS_32B_PLATFORM_2_GEN_1)
+    uint32_t *to_ = (uint32_t *) p_base;
+ #endif
+    const uint32_t * p_data = from;
+    /* Amount is bytes, convert to words */
+    amount /= sizeof(uint32_t);
+    /* Enable access to flash */
+    Flash_enableAccess();
+    for(written = 0; written < amount;)
+    {
+        /* Load base address */
+        Flash_setBaseAddress((uint32_t)(p_base + written));
+        /* How many words until PAGE boundary */
+        p_words = (FLASH_PAGE_SIZE -
+                  ((uint32_t) (p_base + written)) %
+                  FLASH_PAGE_SIZE) / sizeof(uint32_t);
+        /* Increment written */
+        if(p_words > amount - written)
+        {
+            p_words = amount - written;
+        }
+        written += p_words;
+        /* Write words until amount or page boundary */
+        while(p_words--)
+        {
+            uint32_t tmp;
+            // From might not be aligned, but memcpy handles this
+            memcpy(&tmp, p_data, sizeof(uint32_t));
+            Flash_waitWrite();
+            /* Set data shift register */
+            MSC->WDATA = tmp;
+            /* Trigger write once */
+            MSC->WRITECMD = MSC_WRITECMD_WRITEONCE;
+            p_data++;
+            /* Wait for the write to complete */
+            Flash_waitBusy();
+
+#if defined(_SILICON_LABS_32B_PLATFORM_2_GEN_1)
+            // Errata FLASH_E201 – Potential Program Failure after Power On ??
+           if( *to_ != tmp){
+                Flash_setBaseAddress( (uint32_t)to_ );
+                /* Set data shift register */
+                MSC->WDATA = tmp;
+                /* Trigger write once */
+                MSC->WRITECMD = MSC_WRITECMD_WRITEONCE;
+                /* Wait for the write to complete */
+                Flash_waitBusy();
+            }
+            to_++;
+#endif
+
+        }
+    }
+    Flash_disableAccess();
+}
+
+void __attribute__ ((section(".ramtext")))
+Flash_erasePage(size_t page_base)
+{
+    /* Enable writing to the MSC */
+    Flash_enableAccess();
+    /* Load address */
+    Flash_setBaseAddress(page_base);
+    /* Send erase page command */
+    Flash_startErase();
+    /* Wait for the erase to complete */
+    Flash_waitBusy();
+    /* Disable writing to the MSC */
+    Flash_disableAccess();
+}

--- a/v3_to_v5_updater/drivers/flash.h
+++ b/v3_to_v5_updater/drivers/flash.h
@@ -1,0 +1,86 @@
+/* Copyright 2018 Wirepas Ltd. All Rights Reserved.
+ *
+ * See file LICENSE.txt for full license details.
+ *
+ */
+
+#ifndef FLASH_H_
+#define FLASH_H_
+
+#include <stddef.h>
+#include <stdbool.h>
+
+// Page size of system flash from linker script
+extern uint32_t                     __flash_page_size_bytes__;
+
+// Macros for flash access
+#define FLASH_PAGE_SIZE_BYTES       ((uint32_t)&__flash_page_size_bytes__)
+#define FLASH_PAGE_MASK             (0xFFFFFFFF - (FLASH_PAGE_SIZE_BYTES - 1))
+#define Flash_getPage(addr)         ((addr) & FLASH_PAGE_MASK)
+
+// Macro for checking alignment / amount operands.
+// Parameter should be unsigned
+// This avoids using a potentially expensive modulo (division) operand
+#define Flash_isAligned(param)      \
+    (((uint32_t)(param) & (sizeof(uint32_t) - 1)) == 0)
+
+/**
+ * \brief   To initialize flash HW if required by platform.
+ * \return  none
+ */
+void Flash_init(void);
+
+/**
+ * \brief   Enable writing to flash.
+ *          (In NRF5x required also when writing to UICR/FICR registers)
+ * \return  none
+ */
+void Flash_enableWrite(void);
+
+/**
+ * \brief   Enable flash erase.
+ *          (In NRF5x required also when writing to UICR/FICR registers)
+ * \return  none
+ */
+void Flash_enableErase(void);
+
+/**
+ * \brief   Disables write and erase access of the flash.
+ * \return  none
+ */
+void Flash_disableAccess(void);
+
+/**
+ * \brief   Erase one flash page (low level).
+ *          Erasing must be manually enabled/disabled.
+ *          This primitive is not protected by critical sections.
+ * \param   page
+ *          Starting address of the flash page.
+ * \return  none
+ */
+void Flash_erase(size_t page);
+
+/**
+ * \brief   Erase one flash page (high level).
+ *          Handles flash erase enable/disable.
+ *          This primitive is protected by critical sections.
+ * \param   page_base
+ *          Starting address of the flash page.
+ * \return  none
+ */
+void Flash_erasePage(size_t page_base);
+
+/**
+ * \brief   Write data to flash.
+ *          Handles write enable/disable
+ * \param   to
+ *          Flash address to write to
+ * \param   from
+ *          Address to read from
+ * \param   amount
+ *          Bytes to write. Full words i.e. multiple of 4 bytes.
+ * \return  none
+ */
+void Flash_write(void * to, const void * from, size_t amount);
+
+#endif /* FLASH_H_ */

--- a/v3_to_v5_updater/drivers/nrf52832/flash.c
+++ b/v3_to_v5_updater/drivers/nrf52832/flash.c
@@ -1,0 +1,82 @@
+/* Copyright 2018 Wirepas Ltd. All Rights Reserved.
+ *
+ * See file LICENSE.txt for full license details.
+ *
+ */
+
+#include <string.h>
+#include "mcu.h"
+#include "flash.h"
+
+volatile uint32_t EVENT_READBACK;
+
+void Flash_init(void)
+{
+}
+
+/* Low level access for hardware */
+static void Flash_waitBusy(void)
+{
+    while (NRF_NVMC->READY == NVMC_READY_READY_Busy)
+    {
+    }
+}
+
+void Flash_enableWrite(void)
+{
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen;
+    Flash_waitBusy();
+}
+
+void Flash_disableAccess(void)
+{
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren;
+    Flash_waitBusy();
+}
+
+void Flash_enableErase(void)
+{
+    NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Een;
+    Flash_waitBusy();
+}
+
+void Flash_erase(size_t page)
+{
+    NRF_NVMC->ERASEPAGE = (uint32_t)page;
+    Flash_waitBusy();
+    // Fix for NRF52 errata 44 (Flash read fails after erase):
+    EVENT_READBACK = *((uint32_t *)0x10000FFC);
+}
+
+void Flash_write(void * to, const void * from, size_t amount)
+{
+    // NOTE: This variable is necessary, the compiler produces code that fails
+    // if assignment done via *(uint32_t *)to++ = tmp;
+    uint32_t * to_ = (uint32_t *)to;
+    // Writing can be done only in words, so must check alignments
+    /* Enable WRITE */
+    Flash_enableWrite();
+    /* Write data */
+    for(uint32_t tmp = 0;
+        amount > 0;
+        amount -= sizeof(uint32_t),
+        from += sizeof(uint32_t))
+    {
+        // From might not be aligned, but memcpy handles this
+        memcpy(&tmp, from, sizeof(uint32_t));
+        *to_++ = tmp;
+        Flash_waitBusy();
+    }
+    /* Disable WRITE */
+    Flash_disableAccess();
+}
+
+void Flash_erasePage(size_t page_base)
+{
+    /* Enable ERASE */
+    Flash_enableErase();
+    /* Start ERASE */
+    Flash_erase(page_base);
+    /* Disable ERASE */
+    Flash_disableAccess();
+}

--- a/v3_to_v5_updater/hexupdater.py
+++ b/v3_to_v5_updater/hexupdater.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# hexUpdater.py - A tool to prepare an EFR32 stack hex file before v3.x to
+#                 v4.0 upgrade.
+#                 The first page of stack code is moved to the end of area, to
+#                 leave some space for the updater startup code.
+#
+# Requires:
+#   - Python 2 v2.7 or newer (uses argparse, hextool.py)
+#     or Python 3 v3.2 or newer
+#   - hextool.py
+
+import sys
+import os
+import argparse
+import textwrap
+
+FIRST_PAGE_ADDRESS = 0x3A800
+PAGE_SIZE = 2048
+
+# Import hextool.py, but do not write a .pyc file for it.
+dont_write_bytecode = sys.dont_write_bytecode
+sys.dont_write_bytecode = True
+sys.path.append('tools/')
+import hextool
+sys.dont_write_bytecode = dont_write_bytecode
+del dont_write_bytecode
+
+def main():
+    '''Main program'''
+
+    # Determine program name, for error messages.
+    pgmname = os.path.split(sys.argv[0])[-1]
+
+    # Determine help text width.
+    try:
+        help_width = int(os.environ['COLUMNS'])
+    except (KeyError, ValueError):
+        help_width = 80
+    help_width -= 2
+
+    parser = argparse.ArgumentParser(
+        prog = pgmname,
+        formatter_class = argparse.RawDescriptionHelpFormatter,
+        description = textwrap.fill(
+        "A tool to prepare EFR32 stack hex file for v3.x to v4.0 upgrade."))
+
+    parser.add_argument("infilespec",
+        metavar = "INFILESPEC", help = "stack hex file")
+    parser.add_argument("--output", "-o",
+        metavar = "OUTFILESPEC",
+        help = "output file")
+
+    try:
+        args = parser.parse_args()
+
+        memory = hextool.Memory()
+
+        hextool.load_intel_hex(memory, filename = args.infilespec)
+
+        # Move first page off stack just before the v3 bootloader data.
+        first_page = memory[memory.min_address:memory.min_address + PAGE_SIZE]
+        memory.cursor = FIRST_PAGE_ADDRESS
+        memory += first_page
+        del memory[memory.min_address:memory.min_address + PAGE_SIZE]
+
+        if args.output is not None:
+            # Save output file.
+            hextool.save_intel_hex(memory, filename=args.output)
+        else:
+            hextool.save_intel_hex(memory, filename=args.infilespec)
+
+    except (ValueError, IOError, OSError) as exc:
+        sys.stdout.write("%s: %s\n" % (pgmname, exc))
+
+    return 0
+
+
+# Run main.
+if __name__ == "__main__":
+    sys.exit(main())

--- a/v3_to_v5_updater/linker/efr32xg12/gcc_bl_updater_efr32xg12pxxxf1024.ld
+++ b/v3_to_v5_updater/linker/efr32xg12/gcc_bl_updater_efr32xg12pxxxf1024.ld
@@ -1,0 +1,163 @@
+/* Copyright 2018 Wirepas Ltd. All Rights Reserved.
+ *
+ * See file LICENSE.txt for full license details.
+ *
+ */
+
+SEARCH_DIR(.)
+
+/* Flash is 1024 kB and RAM is 128 kB
+ *   - 40 kB of Flash can be used by the app
+ *   - 8 kB (minus 8 bytes) of RAM can be used by the app
+ */
+MEMORY
+{
+    BOOTLOADER (rx)   : ORIGIN = 0x00000000,                LENGTH = 16K - 2K
+    BLCONFIG (rx)     : ORIGIN = 0x00000000 + 14K,          LENGTH = 2K
+    GLUE (rx)         : ORIGIN = 0x00000000 + 16K,          LENGTH = 2K
+    STACK (rx)        : ORIGIN = 0x00000000 + 16K,          LENGTH = 240K
+    FIRST_PAGE (rx)   : ORIGIN = 0x00000000 + 234K,         LENGTH = 2K
+    BL_HEX (rx)       : ORIGIN = 0x00000000 + 236K,         LENGTH = 16K
+    UPDATER (rx)      : ORIGIN = 0x00000000 + 252K,         LENGTH = 4K
+    APPLICATION (rx)  : ORIGIN = 0x00040000,                LENGTH = 40K
+    RAM (rwx)         : ORIGIN = 0x20000000 + 1k,           LENGTH = 127K - 24
+    STACK_GUARD (rwx) : ORIGIN = 0x20000000 + 124K - 8,     LENGTH = 8
+    /* Stack is here: 4 kB - 24 bytes */
+    INVALID (rwx)     : ORIGIN = 0xFFFFFFFF,                LENGTH = 0
+}
+
+__flash_page_size_bytes__   = 2K;
+__bootloader_v3_size__ = LENGTH(BL_HEX);
+
+SECTIONS
+{
+    .bootloader :
+    {
+        /* Bootloader area */
+        __bootloader_start__ = .;
+        . += LENGTH(BOOTLOADER);
+        __bootloader_end__ = .;
+    } >BOOTLOADER
+
+    .blconfig :
+    {
+        /* Bootloader configuration (memory areas, keys) */
+        __blconfig_start__ = .;
+        . += LENGTH(BLCONFIG);
+        __blconfig_end__ = .;
+    } >BLCONFIG
+
+    .glue :
+    {
+        __glue_start__ = .;
+        KEEP(*(.entrypoint))
+        . = ALIGN(16);
+        KEEP(*(.bl_info_header))
+    } >GLUE
+
+    .first_page :
+    {
+        /* Location of the first page of the stack */
+        __first_page_start__ = .;
+        . += LENGTH(FIRST_PAGE);
+        __first_page_end__ = .;
+    } >FIRST_PAGE
+
+    .bl_hex :
+    {
+        /* New Bootloader bytes */
+        __bl_hex_start__ = .;
+        . += LENGTH(BL_HEX);
+        __bl_hex_end__ = .;
+    } >BL_HEX
+
+    .text :
+    {
+        __text_start__ = .;
+        *(.romtext)
+        *(.text.*)
+        *(.text)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.vfp11_veneer)
+        *(.v4_bx)
+        *(.rodata.*)
+        *(.rodata)
+        *(.rodata1)
+        . = ALIGN(8);
+        __text_end__ = .;
+    } >UPDATER
+
+    __data_src_start__ = .;
+
+    .stack :
+    {
+        /* Firmware stack */
+        __stack_start__ = .;
+        . += LENGTH(STACK);
+        __stack_end__ = .;
+    } >STACK
+
+    .application :
+    {
+        /* Application */
+        __application_start__ = .;
+        . += LENGTH(APPLICATION);
+        __application_end__ = .;
+    } >APPLICATION
+
+    .data :
+    {
+        __data_start__ = .;
+        *(.ramtext)
+        *(.data.*)
+        *(.data)
+        *(.data1)
+        . = ALIGN(8);
+        __data_end__ = .;
+    } >RAM AT >UPDATER
+
+    .bss :
+    {
+        __bss_start__ = .;
+        *(.bss.*)
+        *(.bss)
+        *(COMMON)
+        . = ALIGN(8);
+        __bootloader_buffer__ = .;
+        . += __bootloader_v3_size__;
+        . = ALIGN(8);
+        __bss_end__ = .;
+    } >RAM
+
+.invalid :
+    {
+        *(.init)
+        *(.fini)
+        *(.preinit_array)
+        *(.init_array)
+        *(.fini_array)
+        *(.ctors)
+        *(.dtors)
+        *(.jcr)
+        *(.eh_frame)
+        *(.eh_frame_hdr)
+        *(.heap*)
+        *(.tbss)
+        *(.tdata)
+        *(.tdata1)
+        *(.got)
+        *(.got.plt)
+        *(.igot.plt)
+        *(.iplt)
+        *(.rel.dyn)
+        *(.rel.iplt)
+    } >INVALID  /* Linking fails if any of these sections have contents. */
+
+    /* C++ exception unwinding information is silently discarded. */
+    /DISCARD/ :
+    {
+        *(.ARM.extab)
+        *(.ARM.exidx)
+    }
+}

--- a/v3_to_v5_updater/linker/nrf52832/gcc_bl_updater_nrf52832.ld
+++ b/v3_to_v5_updater/linker/nrf52832/gcc_bl_updater_nrf52832.ld
@@ -1,0 +1,154 @@
+/* Copyright 2018 Wirepas Ltd. All Rights Reserved.
+ *
+ * See file LICENSE.txt for full license details.
+ *
+ */
+
+SEARCH_DIR(.)
+
+/* Flash is 512 kB and RAM is 64 kB
+ *   - 40 kB of Flash can be used by the app
+ *   - 8 kB (minus 8 bytes) of RAM can be used by the app
+ */
+MEMORY
+{
+    BOOTLOADER (rx)   : ORIGIN = 0x00000000,                LENGTH = 8K - 1K
+    BLCONFIG (rx)     : ORIGIN = 0x00000000 + 7K,           LENGTH = 1K
+    GLUE (rx)         : ORIGIN = 0x00000000 + 8K,           LENGTH = 8K
+    STACK (rx)        : ORIGIN = 0x00000000 + 16K,          LENGTH = 220K
+    BL_HEX (rx)       : ORIGIN = 0x00000000 + 236K,         LENGTH = 16K
+    UPDATER (rx)      : ORIGIN = 0x00000000 + 252K,         LENGTH = 4K
+    APPLICATION (rx)  : ORIGIN = 0x00040000,                LENGTH = 40K
+    RAM (rwx)         : ORIGIN = 0x20000000 + 1k,           LENGTH = 63K - 24
+    STACK_GUARD (rwx) : ORIGIN = 0x20000000 + 60K - 8,      LENGTH = 8
+    /* Stack is here: 4 kB - 24 bytes */
+    INVALID (rwx)     : ORIGIN = 0xFFFFFFFF,                LENGTH = 0
+}
+
+__flash_page_size_bytes__   = 4K;
+__bootloader_v3_size__ = LENGTH(BL_HEX);
+
+SECTIONS
+{
+    .bootloader :
+    {
+        /* Bootloader area */
+        __bootloader_start__ = .;
+        . += LENGTH(BOOTLOADER);
+        __bootloader_end__ = .;
+    } >BOOTLOADER
+
+    .blconfig :
+    {
+        /* Bootloader configuration (memory areas, keys) */
+        __blconfig_start__ = .;
+        . += LENGTH(BLCONFIG);
+        __blconfig_end__ = .;
+    } >BLCONFIG
+
+    .glue :
+    {
+        __glue_start__ = .;
+        KEEP(*(.entrypoint))
+        . = ALIGN(16);
+        KEEP(*(.bl_info_header))
+    } >GLUE
+
+    .bl_hex :
+    {
+        /* New Bootloader bytes */
+        __bl_hex_start__ = .;
+        . += LENGTH(BL_HEX);
+        __bl_hex_end__ = .;
+    } >BL_HEX
+
+    .text :
+    {
+        __text_start__ = .;
+        *(.text.*)
+        *(.text)
+        *(.glue_7)
+        *(.glue_7t)
+        *(.vfp11_veneer)
+        *(.v4_bx)
+        *(.rodata.*)
+        *(.rodata)
+        *(.rodata1)
+        . = ALIGN(8);
+        __text_end__ = .;
+    } >UPDATER
+
+    __data_src_start__ = .;
+
+    .stack :
+    {
+        /* Firmware stack */
+        __stack_start__ = .;
+        . += LENGTH(STACK);
+        __stack_end__ = .;
+    } >STACK
+
+    .application :
+    {
+        /* Application */
+        __application_start__ = .;
+        . += LENGTH(APPLICATION);
+        __application_end__ = .;
+    } >APPLICATION
+
+
+    .data :
+    {
+        __data_start__ = .;
+        *(.ramtext)
+        *(.data.*)
+        *(.data)
+        *(.data1)
+        . = ALIGN(8);
+        __data_end__ = .;
+    } >RAM AT >UPDATER
+
+    .bss :
+    {
+        __bss_start__ = .;
+        *(.bss.*)
+        *(.bss)
+        *(COMMON)
+        . = ALIGN(8);
+        __bootloader_buffer__ = .;
+        . += __bootloader_v3_size__;
+        . = ALIGN(8);
+        __bss_end__ = .;
+    } >RAM
+
+.invalid :
+    {
+        *(.init)
+        *(.fini)
+        *(.preinit_array)
+        *(.init_array)
+        *(.fini_array)
+        *(.ctors)
+        *(.dtors)
+        *(.jcr)
+        *(.eh_frame)
+        *(.eh_frame_hdr)
+        *(.heap*)
+        *(.tbss)
+        *(.tdata)
+        *(.tdata1)
+        *(.got)
+        *(.got.plt)
+        *(.igot.plt)
+        *(.iplt)
+        *(.rel.dyn)
+        *(.rel.iplt)
+    } >INVALID  /* Linking fails if any of these sections have contents. */
+
+    /* C++ exception unwinding information is silently discarded. */
+    /DISCARD/ :
+    {
+        *(.ARM.extab)
+        *(.ARM.exidx)
+    }
+}

--- a/v3_to_v5_updater/main.c
+++ b/v3_to_v5_updater/main.c
@@ -1,0 +1,354 @@
+/* Copyright 2018 Wirepas Ltd. All Rights Reserved.
+ *
+ * See file LICENSE.txt for full license details.
+ *
+ */
+
+#include <string.h>
+#include <stdint.h>
+#include "flash.h"
+#include "updater.h"
+#include "mcu.h"
+
+/** Addresses determined by the linker */
+extern unsigned int __data_src_start__;
+extern unsigned int __data_start__;
+extern unsigned int __data_end__;
+extern unsigned int __bss_start__;
+extern unsigned int __bss_end__;
+
+extern unsigned int __bl_hex_start__;
+extern unsigned int __bl_hex_end__;
+extern unsigned int __blconfig_start__;
+extern unsigned int __blconfig_end__;
+extern unsigned int __glue_start__;
+extern unsigned int __stack_start__;
+extern unsigned int __stack_end__;
+extern unsigned int __application_start__;
+extern unsigned int __application_end__;
+extern unsigned int __bootloader_v3_size__;
+extern unsigned char __bootloader_buffer__[];
+
+#define BLCONFIG_SIZE      ((uint32_t)&__blconfig_end__ - \
+                            (uint32_t)&__blconfig_start__)
+#define BOOTLOADER_SIZE_V3 ((uint32_t)(&__bootloader_v3_size__))
+#define BLCONFIG_OFFSET    ((uint32_t)(&__blconfig_start__))
+#define BLCONFIG_OFFSET_V3 (BOOTLOADER_SIZE_V3 - BLCONFIG_SIZE)
+#define BLCONFIG_START     ((uint32_t)(&__blconfig_start__))
+#define APPLICATION_START  ((uint32_t)(&__application_start__))
+#define GLUE_START         ((uint32_t)(&__glue_start__))
+#define FIRMWARE_START     ((uint32_t)(&__stack_start__))
+#define FIRMWARE_END       ((uint32_t)(&__stack_end__))
+#define FIRMWARE_SIZE      (FIRMWARE_END - FIRMWARE_START)
+#define BL_HEX_START       ((uint32_t)(&__bl_hex_start__))
+
+/* This is needed to reserve some space for the bootloader to write the
+ * bl_info_header.
+ */
+const bl_info_header_t info_hdr __attribute__(( section (".bl_info_header"))) =
+{
+    .length = 0xFFFFFFFF,
+    .crc = 0xFFFF,
+    .seq = 0xFF,
+    .flags = 0xFF,
+    .id = 0xFFFFFFFF,
+    .major = 0xFF,
+    .minor = 0xFF,
+    .maint = 0xFF,
+    .devel = 0xFF,
+    .written_size = 0xFFFFFFFF,
+};
+
+bl_info_header_t m_stack_header;
+bl_info_header_t m_app_header;
+
+/* This function update the areas definitions to be compatible with the
+ * bootlaoder v3. It does the following :
+ *  - Remove the Firmware no application Area
+ *  - Update the flag fields.
+ *  - Change area id for Firmware and bootloader (|0x100)
+ *  - Update size of the bootlodaer
+ *  - Update size and start address of the stack
+ *  - Add dedicated scratchpad area if needed.
+ */
+static void update_blconfig(void)
+{
+    uint8_t new_idx = 0;
+    uint32_t persistent_begin = 0;
+    uint32_t last_area = 0;
+    uint8_t hw_magic = 0 ;
+
+    memory_area_t * old_areas = (memory_area_t *)BLCONFIG_OFFSET;
+    memory_area_t * new_areas =
+       (memory_area_t *)((uint32_t)&__bootloader_buffer__ + BLCONFIG_OFFSET_V3);
+
+    /* Get app area id */
+    bl_info_header_t * app_info_hdr =
+                (bl_info_header_t *)(APPLICATION_START + BL_INFO_HEADER_OFFSET);
+
+    /* Copy old bootloader config to RAM buffer */
+    memcpy(new_areas, old_areas, BLCONFIG_SIZE);
+
+    /* Set areas fields to 0xFFFFFFFF */
+    memset(new_areas, 0xFF, NUM_MEMORY_AREAS * sizeof(memory_area_t));
+
+    for(int i = 0; i < NUM_MEMORY_AREAS; i++)
+    {
+        /* Undifined Area */
+        if(old_areas[i].id == 0xFFFFFFFF )
+        {
+
+        }
+
+        /* Bootloader area */
+        else if((old_areas[i].id & 0xFFFFFF00) == 0x10000000)
+        {
+            new_areas[new_idx].length = BOOTLOADER_SIZE_V3;
+            new_areas[new_idx].address = old_areas[i].address;
+            /* Modify bootloader area id 0x000000xx -> 0x000001xx */
+            new_areas[new_idx].id = old_areas[i].id | 0x100;
+            /* Overwrite flags */
+            /* Don't store version; internal flash; bootloader */
+            new_areas[new_idx].flags = 0x00000000;
+            new_idx++;
+        }
+
+        /* Firmware Area */
+        else if((old_areas[i].id & 0xFFFFFF00) == 0x00000000)
+        {
+            new_areas[new_idx].length = FIRMWARE_SIZE;
+            new_areas[new_idx].address = FIRMWARE_START;
+            /* Modify firmware area id 0x000000xx -> 0x000001xx */
+            new_areas[new_idx].id = old_areas[i].id | 0x100;
+            /* Overwrite flags */
+            /* Store version; internal flash; stack */
+            new_areas[new_idx].flags = 0x00000005;
+            new_idx++;
+        }
+
+        /* Persitant area */
+        else if((old_areas[i].id & 0xFFFFFF00) == 0x20000000)
+        {
+            new_areas[new_idx].length = old_areas[i].length;
+            new_areas[new_idx].address = old_areas[i].address;
+            new_areas[new_idx].id = old_areas[i].id;
+            /* Overwrite flags */
+            /* Don't store version; internal flash; persistent */
+            new_areas[new_idx].flags = 0x0000000C;
+            new_idx++;
+        }
+
+        /* Application area */
+        else if(old_areas[i].id == app_info_hdr->id)
+        {
+            new_areas[new_idx].length = old_areas[i].length;
+            new_areas[new_idx].address = old_areas[i].address;
+            new_areas[new_idx].id = old_areas[i].id;
+            /* Overwrite flags */
+            /* Store version; internal flash; application */
+            new_areas[new_idx].flags = 0x00000009;
+            new_idx++;
+        }
+
+        /* Firmware no application Area */
+        else if((old_areas[i].id & 0xFFFFFF00) == 0x30000000)
+        {
+            /* Not used anymore, skip */
+        }
+
+        /* This is a User defined area */
+        else
+        {
+            new_areas[new_idx].length = old_areas[i].length;
+            new_areas[new_idx].address = old_areas[i].address;
+            new_areas[new_idx].id = old_areas[i].id;
+            /* Don't store version; internal flash; user */
+            new_areas[new_idx].flags = 0x00000014;
+            new_idx++;
+        }
+    }
+
+    /* Find if scratchpad is in a dedicated area just before persistent area. */
+    for(int i = 0; i < NUM_MEMORY_AREAS; i++)
+    {
+        /* Persitant area */
+        if((new_areas[i].id & 0xFFFFFF00) == 0x20000000)
+        {
+            persistent_begin = new_areas[i].address;
+            hw_magic = new_areas[i].id & 0xFF;
+        }
+        else if(new_areas[i].id != 0xFFFFFFFF )
+        {
+            uint32_t end_area = new_areas[i].address + new_areas[i].length;
+
+            if(end_area > last_area)
+            {
+                last_area = end_area;
+            }
+        }
+    }
+
+    /* Declare scratchpad dedicated area */
+    if(last_area < persistent_begin && new_idx < NUM_MEMORY_AREAS)
+    {
+        new_areas[new_idx].length = persistent_begin - last_area;
+        new_areas[new_idx].address = last_area;
+        new_areas[new_idx].id = 0x30000000 | hw_magic;
+        new_areas[new_idx].flags = 0x00000010;
+    }
+}
+
+static void erase_bootloader_area(size_t num_bytes)
+{
+    uint32_t last_page = Flash_getPage((uint32_t)(num_bytes - 1));
+
+    /* Erase bootlaoder area */
+    for (uint32_t page_base = 0;
+         page_base <= last_page;
+         page_base += FLASH_PAGE_SIZE_BYTES)
+    {
+        Flash_erasePage(page_base);
+    }
+}
+
+/* Update the bl_info_header of the stack.
+ * written_size has been added to v4.0 and was not written by v3.x bootloader.
+ * Also the header is moved because the stack area start at 16k now.
+ */
+static void update_stack_info_header(void)
+{
+    uint32_t * ptr;
+
+    /* firmware area id has changed between v3.x and v4.0*/
+    m_stack_header.id |= 0x100;
+
+    /* Calculate written size */
+    ptr = (uint32_t *)(FIRMWARE_END) - 1;
+
+    while(*ptr == 0xFFFFFFFF && (uint32_t)ptr > FIRMWARE_START)
+    {
+        ptr--;
+    }
+
+    m_stack_header.written_size = Flash_getPage((uint32_t)ptr) +
+                                 FLASH_PAGE_SIZE_BYTES -
+                                 FIRMWARE_START;
+}
+
+
+/* Update the bl_info_header of the application.
+ * written_size has been added to v4.0 and was not written by v3.x bootloader.
+ */
+static void update_app_info_header(void)
+{
+    const app_information_header_t * hdr =
+        (const app_information_header_t *)(APPLICATION_START +
+                                           APP_V2_TAG_OFFSET +
+                                           APP_V2_TAG_LENGTH);
+
+    memcpy(&m_app_header,
+           (void *)(APPLICATION_START + BL_INFO_HEADER_OFFSET),
+           sizeof(bl_info_header_t));
+
+    m_app_header.written_size = Flash_getPage(hdr->length) +
+                              FLASH_PAGE_SIZE_BYTES;
+
+    /* Program only written size field to app info header */
+    Flash_write(&(((bl_info_header_t *)
+                   (APPLICATION_START + BL_INFO_HEADER_OFFSET))->written_size),
+                &m_app_header.written_size,
+                sizeof(m_app_header.written_size));
+}
+
+int main(void)
+{
+    uint8_t * ptr_hex = (uint8_t * )BL_HEX_START;
+
+    unsigned int * src, * dst;
+
+    /* Copy data from flash to RAM */
+    for(src = &__data_src_start__,
+        dst = &__data_start__;
+        dst != &__data_end__;)
+    {
+        *dst++ = *src++;
+    }
+
+    /* Initialize the .bss section */
+    for(dst = &__bss_start__; dst != &__bss_end__;)
+    {
+        *dst++ = 0;
+    }
+
+    Flash_init();
+
+    /* Copy new bootlaoder to RAM buffer */
+    memcpy(&__bootloader_buffer__[0], ptr_hex, BOOTLOADER_SIZE_V3);
+
+    /* Update firmware area id and area flags */
+    update_blconfig();
+
+    /* Backup stack header before erasing area */
+    /* GLUE Start is the actual location of the firmware */
+    memcpy(&m_stack_header,
+    	   (void *)(GLUE_START + BL_INFO_HEADER_OFFSET),
+           sizeof(bl_info_header_t));
+
+
+    /* Erase bootloader area */
+    erase_bootloader_area(BOOTLOADER_SIZE_V3);
+
+    /* Program new bootloader to flash */
+    Flash_write(0, __bootloader_buffer__, BOOTLOADER_SIZE_V3);
+
+
+    /* Update firmware bl_info_header */
+    update_stack_info_header();
+
+    /* Update application bl_info_header */
+    update_app_info_header();
+
+#ifdef NRF52
+    /* Program full info header at the new location*/
+    Flash_write((void *)(FIRMWARE_START + BL_INFO_HEADER_OFFSET),
+                &m_stack_header,
+                sizeof(bl_info_header_t));
+
+#endif
+
+#ifdef EFR32FG12
+    extern unsigned int __first_page_start__;
+
+    /* Erase first page of stack, at this point it contains the updater startup.
+     */
+    Flash_erasePage(FIRMWARE_START);
+
+    /* Copy first page of stack to RAM buffer */
+    memcpy(&__bootloader_buffer__[0],
+           (void *)(&__first_page_start__),
+           FLASH_PAGE_SIZE_BYTES);
+
+    /* Copy updated bl_info_header to RAM buffer */
+    memcpy((void*)(__bootloader_buffer__ + BL_INFO_HEADER_OFFSET),
+           &m_stack_header,
+           sizeof(bl_info_header_t));
+
+    /* Write the first page to flash */
+    Flash_write((void* )FIRMWARE_START,
+                __bootloader_buffer__,
+                FLASH_PAGE_SIZE_BYTES);
+#endif
+
+    /* Reset to start with new bootloader and stack */
+    NVIC_SystemReset();
+}
+
+/* Updater entrypoint from the legacy bootloader.
+ * This section must be less than 16bytes.
+ */
+void __attribute__ ((noreturn, section (".entrypoint"))) entrypoint(void)
+{
+    main();
+
+    while(1);
+}

--- a/v3_to_v5_updater/makefile
+++ b/v3_to_v5_updater/makefile
@@ -1,0 +1,46 @@
+include makefile
+
+.DEFAULT_GOAL := updater
+
+HEX_UPDATE   := python v3_to_v5_updater/hexupdater.py
+
+BUILDPREFIX_UPDATER := $(BUILDPREFIX)updater/
+BOOTLOADER_UPDATER_NAME := $(MCU)$(MCU_SUB)_updater
+BOOTLOADER_UPDATER_HEX := $(BUILDPREFIX_UPDATER)$(BOOTLOADER_UPDATER_NAME).hex
+BOOTLOADER_UPDATER_OTAP := $(BUILDPREFIX_UPDATER)final_$(APP_NAME)_updater.otap
+
+ifeq ($(MCU)$(MCU_SUB)$(MCU_MEM_VAR),efr32xg12pxxxf1024)
+	FW_AREA_ID = 0x00000005
+else ifeq ($(MCU)$(MCU_SUB)$(MCU_MEM_VAR),nrf52832)
+	FW_AREA_ID = 0x00000003
+else
+	$(error Specified target board $(target_board) ($(MCU)$(MCU_SUB)$(MCU_MEM_VAR)) is not suported by the updater tool)
+endif
+
+.PHONY: updater
+updater: $(BOOTLOADER_HEX) $(STACK_HEX) $(APP_HEX) $(BOOTLOADER_CONFIG_INI)
+	+$(MAKE)  -f makefile_bootloader.mk
+	+$(MAKE)  -f makefile_stack.mk
+	+$(MAKE)  -f makefile_app.mk
+	+$(MAKE)  -f v3_to_v5_updater/makefile_updater.mk BUILDPREFIX_UPDATER=$(BUILDPREFIX_UPDATER) BOOTLOADER_UPDATER_NAME=$(BOOTLOADER_UPDATER_NAME)
+ifeq ($(MCU),efr32)
+		$(HEX_UPDATE) $(STACK_HEX) -o $(BUILDPREFIX_UPDATER)wsn_stack.hex
+else
+		$(CP) $(STACK_HEX) $(BUILDPREFIX_UPDATER)wsn_stack.hex
+endif
+	$(HEXTOOL) $(BOOTLOADER_HEX) --delete 0xfe04000-0xfe04200  -o $(BUILDPREFIX_UPDATER)bootloader.hex
+	$(eval output_file:=$(BUILDPREFIX_UPDATER)combined.hex)
+	$(HEXTOOL) --output=hex:$(output_file) hex:$(BUILDPREFIX_UPDATER)wsn_stack.hex hex:$(BOOTLOADER_UPDATER_HEX) hex@0x3B000:$(BUILDPREFIX_UPDATER)bootloader.hex
+	$(SCRAT_GEN)    --configfile=$(BOOTLOADER_CONFIG_INI) \
+	                --otapseq=$(otap_seq_number) \
+	                --set=APP_AREA_ID=$(app_area_id) \
+	                $(BOOTLOADER_UPDATER_OTAP) \
+	                $(patsubst %.hex,%.conf,$(STACK_HEX)):$(FW_AREA_ID):$(output_file) \
+	                $(app_major).$(app_minor).$(app_maintenance):$(app_area_id):$(APP_HEX)
+
+.PHONY: clean_updater
+clean_updater:
+	+$(MAKE)  -f makefile_bootloader.mk clean
+	+$(MAKE)  -f makefile_app.mk clean
+	+$(MAKE)  -f v3_to_v5_updater/makefile_updater.mk clean
+	$(RM) -rf $(BUILDPREFIX_UPDATER)$(APP_NAME)_updater.otap

--- a/v3_to_v5_updater/makefile_updater.mk
+++ b/v3_to_v5_updater/makefile_updater.mk
@@ -1,0 +1,47 @@
+include makefile_common.mk
+
+.DEFAULT_GOAL := all
+
+# Linker for the updater
+LDSCRIPT := v3_to_v5_updater/linker/$(MCU)$(MCU_SUB)/gcc_bl_updater_$(MCU)$(MCU_SUB)$(MCU_MEM_VAR).ld
+
+BUILDPREFIX_UPDATER := $(BUILDPREFIX)updater/
+BOOTLOADER_UPDATER_NAME := $(MCU)$(MCU_SUB)_updater
+BOOTLOADER_UPDATER_ELF := $(BUILDPREFIX_UPDATER)$(BOOTLOADER_UPDATER_NAME).elf
+BOOTLOADER_UPDATER_HEX := $(BUILDPREFIX_UPDATER)$(BOOTLOADER_UPDATER_NAME).hex
+
+#
+# Sources & includes paths
+#
+SRCS += v3_to_v5_updater/drivers/$(MCU)$(MCU_SUB)/flash.c
+SRCS += v3_to_v5_updater/main.c
+
+CFLAGS += -Iv3_to_v5_updater/drivers/
+CFLAGS += -Imcu/$(MCU)/
+
+# Objects list
+OBJS_ = $(SRCS:.c=.o)
+OBJS = $(addprefix $(BUILDPREFIX_UPDATER), $(OBJS_))
+
+# Files to be cleaned
+CLEAN := $(OBJS) $(BOOTLOADER_UPDATER_ELF) $(BOOTLOADER_UPDATER_HEX)
+
+$(BUILDPREFIX_UPDATER)%.o : %.c
+	$(MKDIR) $(@D)
+	$(CC) $(INCLUDES) $(CFLAGS) -c $< -o $@
+
+$(BOOTLOADER_UPDATER_ELF): $(OBJS)
+	$(MKDIR) $(@D)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ \
+	      -Wl,-Map=$(BUILDPREFIX_UPDATER)$(BOOTLOADER_UPDATER_NAME).map \
+	      -Wl,-T,$(LDSCRIPT) $(LIBS)
+
+$(BOOTLOADER_UPDATER_HEX): $(BOOTLOADER_UPDATER_ELF)
+	@echo "Generating $(BOOTLOADER_UPDATER_HEX)"
+	$(OBJCOPY) $< -O ihex $@
+
+.PHONY: all
+all: $(BOOTLOADER_UPDATER_HEX)
+
+clean:
+	$(RM) -rf $(CLEAN)

--- a/v3_to_v5_updater/updater.h
+++ b/v3_to_v5_updater/updater.h
@@ -1,0 +1,91 @@
+/* Copyright 2018 Wirepas Ltd. All Rights Reserved.
+ *
+ * See file LICENSE.txt for full license details.
+ *
+ */
+
+ #include <stddef.h>
+
+/** \brief  Maximum number of memory areas */
+#define NUM_MEMORY_AREAS    8
+
+/**
+ * \brief Offset from start of area for \ref bl_info_header_t, in bytes
+ * \note  This must match the actual offset of \ref __saved_bl_info_header__
+ *        in scratchpad_header.s
+ */
+#define BL_INFO_HEADER_OFFSET       16
+
+/** Byte offset of \ref APP_V2_TAG from the start of application memory area */
+#define APP_V2_TAG_OFFSET           48
+
+/** Length of \ref APP_V2_TAG, in bytes */
+#define APP_V2_TAG_LENGTH           16
+
+/**
+ * \brief   Memory area information in .blconfig section
+ */
+typedef struct
+{
+    /** Start address of memory area */
+    uint32_t address;
+    /** Number of bytes in memory area */
+    uint32_t length;
+    /** ID of memory area */
+    uint32_t id;
+    /** Flags */
+    uint32_t flags;
+} memory_area_t;
+
+/**
+ * \brief  Bootloader information header
+ *
+ * Bootloader can be requested to store this header in an empty area in the
+ * beginning of the firmware, at \ref BL_INFO_HEADER_OFFSET.
+ */
+typedef struct
+{
+    /** Number of bytes of scratchpad, not including header and tag */
+    uint32_t length;
+    /** CRC16-CCITT of scratchpad, not including any header or tag bytes */
+    uint16_t crc;
+    /** Sequence number of data in scratchpad: \ref BL_SCRATCHPAD_MIN_SEQ .. \ref BL_SCRATCHPAD_MAX_SEQ */
+    uint8_t seq;
+    /** Flags are used by the stack to determine if the scratchpad must be
+     *  taken into use if the connection to the sink is lost for more than
+     *  one hour (MANUAL or AUTO_PROCESS). These flags are don't care for
+     *  the bootloader and are not defined here.
+     */
+    uint8_t flags;
+    /** Memory area ID of firmware */
+    uint32_t id;
+    /** Firmware major version number component */
+    uint8_t major;
+    /** Firmware minor version number component */
+    uint8_t minor;
+    /** Firmware maintenance version number component */
+    uint8_t maint;
+    /** Firmware development version number component */
+    uint8_t devel;
+    /** Size of the data written in the area after decrompression */
+    uint32_t written_size;
+} bl_info_header_t;
+
+/**
+ * \brief   Application information header
+ *
+ * If an application is compiled to support application API v2, this header
+ * can found in the beginning of the application memory area. It is placed
+ * right after the \ref APP_V2_TAG, which is at \ref APP_V2_TAG_OFFSET.
+ */
+typedef struct
+{
+    /** Expected API version of application */
+    uint32_t api_version;
+    /** Expected start address of application memory area, for sanity checks */
+    uint32_t start_address;
+    /** Total number of bytes used in the application memory area */
+    uint32_t length;
+    /** Padding, reserved for future use, must be 0 */
+    uint32_t pad;
+} app_information_header_t;


### PR DESCRIPTION
This is a modified version of the bootloader updater (originally distributed in SDK with stack V4.0) to update a v3.x network running with the legacy bootloader directly to the v5.0 stack (with the new 16k bootloader).