### PR TITLE
build applications that are in the source directory

### DIFF
--- a/makefile_common.mk
+++ b/makefile_common.mk
@@ -130,7 +130,7 @@ INCLUDES += -Imcu/$(MCU) -Imcu/$(MCU)/hal -Imcu/$(MCU)/vendor -Imcu/$(MCU)/cmsis
 
 # Folder where the application sources are located (and config file)
 # Can be in different folders, try them one by one
-APP_SRCS_PATH := $(wildcard source/*/$(app_name)/)
+APP_SRCS_PATH := $(wildcard source/*/$(app_name)/ source/$(app_name)/)
 ifeq (,$(wildcard $(APP_SRCS_PATH)))
 $(error App $(app_name) doesn't exist)
 endif


### PR DESCRIPTION
Having folders is a good option, but make it mandatory
will make the maintenance of existing application painful
because patches will not apply between versions.

So let's build applications that are in the source directory,
where they used to be