### PR TITLE
build: make board directory configurable

### DIFF
--- a/board/makefile
+++ b/board/makefile
@@ -1,6 +1,6 @@
-INCLUDES += -Iboard/
+INCLUDES += -I$(BOARDS_PATH)
 
-SRCS += board/board_init.c
+SRCS += $(BOARDS_PATH)board_init.c
 
 # Include custom board makefile, where board specific source files can be added
 # Does nothing, if file does not exist

--- a/makefile
+++ b/makefile
@@ -127,7 +127,7 @@ need_board:
 	        A default value can be set in main config.mk file))
 
 	# Check if board really exist
-	@test -s board/$(target_board)/config.mk || \
+	@test -s $(BOARD_CONFIG) || \
 		   { echo "Specified target board $(target_board) doesn't exist. Available boards are: $(AVAILABLE_BOARDS)"; exit 1; }
 
 initial_setup: $(LICENSE_ACCEPTED) $(KEY_FILE)

--- a/makefile_app.mk
+++ b/makefile_app.mk
@@ -34,7 +34,7 @@ CFLAGS += -DNET_AUTHEN_KEY=$(default_network_authen_key)
 endif
 
 # Include board init part
--include board/makefile
+-include $(BOARDS_PATH)makefile
 
 # Include app specific makefile
 -include $(APP_SRCS_PATH)makefile

--- a/makefile_bootloader.mk
+++ b/makefile_bootloader.mk
@@ -20,7 +20,7 @@ BOOTLOADER_ELF := $(BL_BUILDPREFIX)bootloader.elf
 -include bootloader/makefile
 
 # Include board part (for BOARD_HW_xx defines)
--include board/makefile
+-include $(BOARDS_PATH)makefile
 
 # Include HAL drivers code (needed to build power.c (DCDC))
 -include $(HAL_API_PATH)makefile

--- a/makefile_common.mk
+++ b/makefile_common.mk
@@ -103,7 +103,7 @@ FIRMWARE_NAME := wpc_stack
 
 
 # Board config file
-BOARD_CONFIG := board/$(target_board)/config.mk
+BOARD_CONFIG := $(BOARDS_PATH)$(target_board)/config.mk
 
 # Include board specific config
 -include $(BOARD_CONFIG)
@@ -126,7 +126,7 @@ CFLAGS += -D$(MCU_UPPER)
 
 CFLAGS += -march=$(ARCH)
 
-INCLUDES += -Imcu/$(MCU) -Imcu/$(MCU)/hal -Imcu/$(MCU)/vendor -Imcu/$(MCU)/cmsis -Iboard/$(target_board)
+INCLUDES += -Imcu/$(MCU) -Imcu/$(MCU)/hal -Imcu/$(MCU)/vendor -Imcu/$(MCU)/cmsis -I$(BOARDS_PATH)/$(target_board)
 
 # Folder where the application sources are located (and config file)
 # Can be in different folders, try them one by one


### PR DESCRIPTION
Since wm-sdk could be used as an external repository where code and
board configuration could be defined, and $(BOARDS_PATH) already
exists (as IMAGE_PATH or GLOBAL_BUILD), use it rather than using
the hardcoded 'board/'.