### PR TITLE
debug: cast buffer to uint8 on log

### DIFF
--- a/util/debug_log.h
+++ b/util/debug_log.h
@@ -195,7 +195,7 @@
     if(((uint8_t) level) <= ((uint8_t) DEBUG_LOG_MAX_LEVEL)) { \
         for (uint8_t i = 0; i < size; i++) \
         { \
-            Print_Log("%02X ", buffer[i]); \
+            Print_Log("%02X ", ((uint8_t *)buffer)[i]); \
             if ((i & 0xF) == 0xF && i != (uint8_t)(size-1)) \
             { \
                 Print_Log("\n"); \


### PR DESCRIPTION
To:
- deref an uint8_t (otherwise the value could be an uint32_t)
- fix deref size, since with pass the sizeof. For a pointer
  to a single struct with overflow the struct.

Typical usage:
```c
struct {
        uint32_t x;
        uint32_t y;
        uint8_t data[10];
} foo;
LOG_BUFFER(LVL_DEBUG, &foo, sizeof(foo));
```