### PR TITLE
fix: send_ack_packet no longer causes unexpected behaviour if shared data lib fails to send

### DIFF
--- a/libraries/provisioning/provisioning.c
+++ b/libraries/provisioning/provisioning.c
@@ -228,23 +228,25 @@ static uint32_t send_ack_packet(void)
     res = Shared_Data_sendData(&data_to_send, packet_sent_cb);
     if (res != APP_LIB_DATA_SEND_RES_SUCCESS)
     {
-        LOG(LVL_WARNING, "State WAIT_DATA : Error sending ACK (res:%d).", res);
-        return APP_SCHEDULER_SCHEDULE_ASAP;
+        LOG(LVL_WARNING, "State WAIT_DATA : Error sending ACK (res:%u).", res);
+        // Timeout immediately as the packet failed to send
+        m_timeout_ms = APP_SCHEDULER_SCHEDULE_ASAP;
     }
     else
     {
         /* Set a timeout in case the packets takes to much time
-            * to be sent.
-            */
+        * to be sent.
+        */
         m_timeout_ms = m_conf.timeout_s * 1000;
-        if (App_Scheduler_addTask_execTime(timeout_task,
+    }
+
+    if (App_Scheduler_addTask_execTime(timeout_task,
                                     m_timeout_ms,
                                     500) != APP_SCHEDULER_RES_OK)
-        {
-            reset_provisioning();
-            m_conf.end_cb(PROV_RES_ERROR_INTERNAL);
-            LOG(LVL_ERROR, "State WAIT_DATA : Error adding task.");
-        }
+    {
+        reset_provisioning();
+        m_conf.end_cb(PROV_RES_ERROR_INTERNAL);
+        LOG(LVL_ERROR, "State WAIT_DATA : Error adding task.");
     }
 
     return APP_SCHEDULER_STOP_TASK;


### PR DESCRIPTION
Hi,

This is a pull request to fix a bug contained in the provisioning library which can cause the provisioning library to exit early and enter an invalid state. 

## Bug

When a failure occurs while sending an `ack` packet to the provisioning server using the shared data library the failure is handled by returning `APP_SCHEDULER_SCHEDULE_ASAP`. This causes the state machine to exit early and the library to be "stuck" in the state. Consequently, the initiator's end of provisioning callback is never called so it may stall the behaviour of their system awaiting this call. 

Furthermore, the code explicitly states in a comment that the ACK is optional and in the event of a failure the provisioning process should move to the next state; which it does not in this case.

## Proposed fix

The fix proposed in this pull request instead handles this as an "immediate timeout". This causes a timeout event to occur and the system to proceed as usual.

An alternative fix could be to explicitly set `m_events.timeout = 1` instead of starting the timeout task (which does this).